### PR TITLE
Twilio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 
 # Ignore application configuration
 /config/application.yml
+/spec/cassettes

--- a/app/controllers/api/v1/games/shots_controller.rb
+++ b/app/controllers/api/v1/games/shots_controller.rb
@@ -6,7 +6,7 @@ module Api
         before_action :validate,  only: [:create]
 
         def create
-          # return twilio if validate
+          # twilio #works fine, but is sending too many texts when the spec_harness is run 
           render json: @game, message: processor.message
         end
 


### PR DESCRIPTION
Commented out calling twilio methdo in the create action in shots controller as it's being called too often when running spec harness (sending too many texts when running spec harness).